### PR TITLE
Add extra info (analytic, product, taxes, correct account) to invoice line

### DIFF
--- a/budget_invoice/model/budget_line.py
+++ b/budget_invoice/model/budget_line.py
@@ -52,7 +52,7 @@ class BudgetLine(orm.Model):
                 uom_id=False,
                 qty=0,
                 name=budget_line.name or u'/',
-                type='in_invoice',
+                type='out_invoice',
                 partner_id=partner.id,
                 fposition_id=False,
                 price_unit=budget_line.amount,

--- a/budget_invoice/model/budget_line.py
+++ b/budget_invoice/model/budget_line.py
@@ -46,10 +46,34 @@ class BudgetLine(orm.Model):
         invoice_id = invoice_obj.create(cr, uid, invoice_data, context)
 
         for budget_line in self.browse(cr, uid, ids, context):
+            product_onchange_result = invoice_line_obj.product_id_change(
+                cr, uid, [],
+                product.id,
+                uom_id=False,
+                qty=0,
+                name=budget_line.name or u'/',
+                type='in_invoice',
+                partner_id=partner.id,
+                fposition_id=False,
+                price_unit=budget_line.amount,
+                currency_id=False,
+                context=context,
+                company_id=(budget_line.analytic_account_id and
+                            budget_line.analytic_account_id.company_id.id or
+                            None),
+            )
             invoice_line_data = {
+                'product_id': product.id,
+                'account_id': product_onchange_result['value']['account_id'],
                 'name': budget_line.name or u'/',
+                'uos_id': product_onchange_result['value']['uos_id'],
                 'price_unit': budget_line.amount,
                 'invoice_id': invoice_id,
+                'invoice_line_tax_id': [
+                    (6, 0,
+                     product_onchange_result['value']['invoice_line_tax_id'])
+                ],
+                'account_analytic_id': budget_line.analytic_account_id.id,
             }
             invoice_line_obj.create(cr, uid, invoice_line_data, context)
 


### PR DESCRIPTION
This PR is to add extra information to the invoices lines created from a budget line. Mainly, the product_id is set in the line, and the product_id_change is called to retrieve both the correct account_id (depending on the product category) and the taxes.
