### PR TITLE
Add try/except if order key is not in res (ex: date)

### DIFF
--- a/budget/budget_line.py
+++ b/budget/budget_line.py
@@ -389,5 +389,8 @@ class budget_line(orm.Model):
                 reverse = (order[0][1] == 'DESC')
             getter = [x[0] for x in order if x[0]]
             if getter:
-                res = sorted(res, key=itemgetter(*getter), reverse=reverse)
+                try:
+                    res = sorted(res, key=itemgetter(*getter), reverse=reverse)
+                except KeyError:
+                    pass
         return res


### PR DESCRIPTION
This PR is to add a try/except in order to not return an exception because the sorting key is not in `super()` (main reason being that the "grouped" lines cannot get a "sum" result, ex: with dates).
