### PR TITLE
[16.0][FIX] account_budget_oca: `image_128` -> `avatar_128` (forward port)

### DIFF
--- a/account_budget_oca/views/account_budget_views.xml
+++ b/account_budget_oca/views/account_budget_views.xml
@@ -311,7 +311,7 @@
                                 <div class="oe_kanban_bottom_right">
                                     <span class="pull-right">
                                         <img
-                                            t-att-src="kanban_image('res.users', 'image_small', record.creating_user_id.raw_value)"
+                                            t-att-src="kanban_image('res.users', 'avatar_128', record.creating_user_id.raw_value)"
                                             t-att-title="record.creating_user_id.value"
                                             t-att-alt="record.creating_user_id.value"
                                             width="24"


### PR DESCRIPTION
Forward port of https://github.com/OCA/account-budgeting/pull/72.