### PR TITLE
[16.0][FIX] account_budget_oca: fix operation error _compute_practica…

### DIFF
--- a/account_budget_oca/models/account_budget.py
+++ b/account_budget_oca/models/account_budget.py
@@ -151,7 +151,7 @@ class CrossoveredBudgetLines(models.Model):
             acc_ids = line.general_budget_id.account_ids.ids
             date_to = line.date_to
             date_from = line.date_from
-            if line.analytic_account_id.id:
+            if line.analytic_account_id.id and date_from and date_to:
                 self.env.cr.execute(
                     """
                     SELECT SUM(amount)


### PR DESCRIPTION
When an Analytic Account is selected and the **Period** has not been set yet, the following error appears:


![image](https://github.com/user-attachments/assets/88441e1a-3277-42b3-b048-639cd9b7f982)


```
  File "/opt/odoo/auto/addons/account_budget_oca/models/account_budget.py", line 155, in _compute_practical_amount
    self.env.cr.execute(
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 321, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.UndefinedFunction: operator does not exist: date >= boolean
LINE 5:                         AND (date between false
                                          ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.


The above server error caused the following client error:
null
```

The problem is that the query is comparing incompatible operators (date and boolean, because we have not selected date yet):

```
                self.env.cr.execute(
                    """
                    SELECT SUM(amount)
                    FROM account_analytic_line
                    WHERE account_id=%s
                        AND (date between %s
                        AND %s)
                        AND general_account_id=ANY(%s)""",
                    (line.analytic_account_id.id, date_from, date_to, acc_ids),
                )
```