### PR TITLE
[14.0][IMP] account_budget_oca: improve budget lines subform view in analytic acount view

### DIFF
--- a/account_budget_oca/views/account_analytic_account_views.xml
+++ b/account_budget_oca/views/account_analytic_account_views.xml
@@ -35,12 +35,14 @@
                                 <field name="percentage" />
                             </tree>
                             <form>
-                                <field name="crossovered_budget_id" />
-                                <field name="general_budget_id" />
-                                <field name="date_from" />
-                                <field name="date_to" />
-                                <field name="paid_date" />
-                                <field name="planned_amount" widget="monetary" />
+                                <group>
+                                    <field name="crossovered_budget_id" />
+                                    <field name="general_budget_id" />
+                                    <field name="date_from" />
+                                    <field name="date_to" />
+                                    <field name="paid_date" />
+                                    <field name="planned_amount" widget="monetary" />
+                                </group>
                             </form>
                         </field>
                     </page>


### PR DESCRIPTION
The subform displaying the budget lines in the analytic account view form lacks a <group> to be properly displayed.
This PR fixes it.
