### PR TITLE
[18.0][IMP] account_budget_oca: Add the possibility to compute budgets based on journal entries instead of analytic entries

### DIFF
--- a/account_budget_oca/models/account_budget.py
+++ b/account_budget_oca/models/account_budget.py
@@ -145,18 +145,29 @@ class CrossoveredBudgetLines(models.Model):
             acc_ids = line.general_budget_id.account_ids.ids
             date_to = line.date_to
             date_from = line.date_from
-            if line.analytic_account_id.id and date_from and date_to:
-                self.env.cr.execute(
-                    """
-                    SELECT SUM(amount)
-                    FROM account_analytic_line
-                    WHERE account_id=%s
-                        AND (date between %s
-                        AND %s)
-                        AND general_account_id=ANY(%s)""",
-                    (line.analytic_account_id.id, date_from, date_to, acc_ids),
-                )
-                result = self.env.cr.fetchone()[0] or 0.0
+            if date_from and date_to and acc_ids:
+                if line.analytic_account_id:
+                    data = self.env["account.analytic.line"]._read_group(
+                        [
+                            ("account_id", "=", line.analytic_account_id.id),
+                            ("date", ">=", date_from),
+                            ("date", "<=", date_to),
+                            ("general_account_id", "in", acc_ids),
+                        ],
+                        aggregates=["amount:sum"],
+                    )
+                    result = data[0][0] if data else 0.0
+                else:
+                    data = self.env["account.move.line"]._read_group(
+                        [
+                            ("account_id", "in", acc_ids),
+                            ("date", ">=", date_from),
+                            ("date", "<=", date_to),
+                            ("parent_state", "=", "posted"),
+                        ],
+                        aggregates=["balance:sum"],
+                    )
+                    result = -data[0][0] if data else 0.0
             line.practical_amount = result
 
     @api.depends("paid_date", "date_from", "date_to", "planned_amount")

--- a/account_budget_oca/tests/test_account_budget.py
+++ b/account_budget_oca/tests/test_account_budget.py
@@ -85,3 +85,43 @@ class TestAccountBudget(TestAccountBudgetCommon):
 
         # I check that budget is in "done" state
         self.assertEqual(budget.state, "done")
+
+    def test_budget_with_account_move_lines(self):
+        Budget = self.env["crossovered.budget"]
+        date_from = Date.start_of(Date.context_today(Budget), "year")
+        date_to = Date.end_of(Date.context_today(Budget), "year")
+        budget = Budget.create(
+            {"date_from": date_from, "date_to": date_to, "name": "Budget"}
+        )
+        budget_line = self.env["crossovered.budget.lines"].create(
+            {
+                "crossovered_budget_id": budget.id,
+                "general_budget_id": self.account_budget_post_sales0.id,
+                "date_from": date_from,
+                "date_to": date_to,
+                "planned_amount": -1000.0,
+            }
+        )
+
+        budget_account = self.account_budget_post_sales0.account_ids[:1]
+        self._create_invoice(
+            move_type="out_invoice",
+            date=date_from,
+            post=True,
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    price_unit=250.0, account_id=budget_account.id
+                )
+            ],
+        )
+        self._create_invoice(
+            move_type="in_invoice",
+            date=date_from,
+            post=True,
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    price_unit=150.0, account_id=budget_account.id
+                )
+            ],
+        )
+        self.assertAlmostEqual(budget_line.practical_amount, 100.0)

--- a/account_budget_oca/views/account_budget_views.xml
+++ b/account_budget_oca/views/account_budget_views.xml
@@ -174,7 +174,6 @@
                                     <field
                                         name="analytic_account_id"
                                         groups="analytic.group_analytic_accounting"
-                                        required="1"
                                     />
                                     <field name="date_from" />
                                     <field name="date_to" />
@@ -201,7 +200,6 @@
                                             <field
                                                 name="analytic_account_id"
                                                 groups="analytic.group_analytic_accounting"
-                                                required="1"
                                             />
                                         </group>
                                         <group>


### PR DESCRIPTION
In some cases, you may want to use the budget feature without analytic accounts. In this case, `analytic_account_id` can be empty, and `account_ids` can be set on `account.budget.post`.

TT59878
@Tecnativa @pedrobaeza @eduezerouali-tecnativa could you please review this?